### PR TITLE
compile without needing checkouts for gamma and gamma-driver

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,6 +13,7 @@
                  [fipp "0.6.2"]
                  [instaparse "1.4.0"]
                  [kovasb/gamma-driver "0.0-49"]
+                 [kovasb/gamma "0.0-135"]
                  [markdown-clj "0.9.66"]
                  [org.omcljs/om "0.8.8"]
                  [org.clojure/clojure "1.7.0-beta3"]

--- a/src/cljs/gampg/learn_gamma/apartment.cljs
+++ b/src/cljs/gampg/learn_gamma/apartment.cljs
@@ -462,7 +462,7 @@
                            reflection-direction      (g/reflect (g/* -1 light-direction) normal)
                            specular-light-weighting  (-> (g/dot reflection-direction eye-direction)
                                                          (g/max 0)
-                                                         (g/pow u-material-shininess))
+                                                         (g/power u-material-shininess))
                            diffuse-light-weighting (-> (g/dot normal light-direction)
                                                        (g/max 0))
                            light-weighting           (-> (g/+ u-ambient-color u-point-lighting-specular-color)
@@ -511,7 +511,7 @@
     :fragment-shader {(g/gl-frag-color) (let [t (g/* u-view-direction-projection-inverse v-sky-box-position)]
                                           (->> (g/div (g/swizzle t :xyz)
                                                       (g/swizzle t :w))
-                                               g/normalize 
+                                               g/normalize
                                                (g/textureCube u-sky-box-sampler ))
                                           ;;(g/vec4 1 (g/swizzle v-sky-box-position :y) 0 1)
                                           )}
@@ -538,7 +538,7 @@
     :precision       {:float :mediump}}))
 
 (defn get-perspective-matrix
-  "Be sure to 
+  "Be sure to
    1. pass the WIDTH and HEIGHT of the canvas *node*, not
       the GL context
    2. (set! (.-width/height canvas-node)
@@ -619,7 +619,7 @@
     :mapping-fn     (fn [x] (or (:id x) (:element x) x))
     :input-state    (atom {})
     :input-fn       my-input-fn
-    :produce-fn     driver/default-produce-fn}))
+    :produce-fn     driver/produce}))
 
 (defn reset-gl-canvas! [canvas-node]
   (let [gl     (.getContext canvas-node "webgl")
@@ -672,13 +672,13 @@
                    0                    0     0                   1])))
 
 (def sky-box-vertices
-  {:data [-1  1  1 
-              1  1  1 
-              1 -1  1 
-              -1 -1  1 
-              -1  1 -1 
-              1  1 -1 
-              1 -1 -1 
+  {:data [-1  1  1
+              1  1  1
+              1 -1  1
+              -1 -1  1
+              -1  1 -1
+              1  1 -1
+              1 -1 -1
               -1 -1 -1]
    :id :sky-box-vertices
    :immutable? true})
@@ -826,7 +826,7 @@
         ;;
         ]
     ;;(js/console.log "draw-sky-box")
-    
+
     (draw-sky-box driver (get-in state [:runtime :programs :sky-box]) state p (get-in state [:skybox :texture])
                   (- (:pitch camera))
                   (- (:yaw camera)))
@@ -984,7 +984,7 @@
   (let [histories                (or (:histories opts)
                                      (atom {}))
         [controls-ch
-         stop-ch    
+         stop-ch
          keyboard-ch]            [(get-in @app-state [:comms :controls])
          (get-in @app-state [:comms :stop])
          (get-in @app-state [:comms :keyboard])]
@@ -1062,7 +1062,7 @@
         combined   (let [comb (-> (get-in mesh-1 [:primitives 0])
                                   (combine-primitives (get-in mesh-2 [:primitives 0]))
                                   (combine-primitives (get-in mesh-3 [:primitives 0])))]
-                     
+
                      (js/console.log "comb: " (clj->js comb))
                      (js/console.log "m3: " (clj->js (get-in mesh-3 [:primitives 0])))
                      (js/console.log "comb m3: " (clj->js (combine-primitives comb (get-in mesh-3 [:primitives 0]))))
@@ -1378,7 +1378,7 @@
         (utils/fix-webgl-inspector-quirks true true 250)
         (aset js/window "processedGLTF" (clj->js scene))
         (aset js/window "scene" scene)
-        
+
         (when-let [capture (and (:capture-first-frame? initial-query-map)
                                 (.-captureNextFrame js/window))]
           (.call capture))

--- a/src/cljs/gampg/learn_gamma/lesson_14.cljs
+++ b/src/cljs/gampg/learn_gamma/lesson_14.cljs
@@ -90,7 +90,7 @@
                            reflection-direction      (g/reflect (g/* -1 light-direction) normal)
                            specular-light-weighting  (-> (g/dot reflection-direction eye-direction)
                                                          (g/max 0)
-                                                         (g/pow u-material-shininess))
+                                                         (g/power u-material-shininess))
                            diffuse-light-weighting (-> (g/dot normal light-direction)
                                                        (g/max 0))
                            light-weighting           (-> (g/+ u-ambient-color u-point-lighting-specular-color)

--- a/src/cljs/gampg/learn_gamma/lesson_15.cljs
+++ b/src/cljs/gampg/learn_gamma/lesson_15.cljs
@@ -107,7 +107,7 @@
                                                          (g/* 255))
                            specular-light-weighting  (-> (g/dot reflection-direction eye-direction)
                                                          (g/max 0)
-                                                         (g/pow shininess))
+                                                         (g/power shininess))
                            diffuse-light-weighting   (-> (g/dot normal light-direction)
                                                          (g/max 0))
                            light-weighting           (g/+ u-ambient-color
@@ -122,7 +122,7 @@
     :precision {:float :mediump}}))
 
 (defn get-perspective-matrix
-  "Be sure to 
+  "Be sure to
    1. pass the WIDTH and HEIGHT of the canvas *node*, not
       the GL context
    2. (set! (.-width/height canvas-node)
@@ -330,7 +330,7 @@
                                                                                          (assoc-in [:scene :color-texture] color-texture)
                                                                                          (assoc-in [:scene :specular-texture] specular-texture)
                                                                                          (assoc-in [:scene :sphere] sphere))))]
-        
+
         (if manual-step-frame-by-frame?
           (set! (.-tick js/window) next-tick)
           (do (<! (async/timeout 100))

--- a/src/cljs/gampg/learn_gamma/programs.cljs
+++ b/src/cljs/gampg/learn_gamma/programs.cljs
@@ -146,7 +146,7 @@
                                                          (g/reflect normal))
                            specular-light-brightness (-> (g/dot reflection-direction eye-direction)
                                                          (g/max 0)
-                                                         (g/pow u-material-shininess))
+                                                         (g/power u-material-shininess))
                            specular-light-weighting  (g/* u-point-lighting-diffuse-color specular-light-brightness)
                            diffuse-light-brightness  (-> (g/dot normal light-direction)
                                                          (g/max 0))
@@ -235,7 +235,7 @@
         shininess        8 ;; Why 8?
         specular-factor  (-> (g/dot r e)
                              (g/clamp 0 1)
-                             (g/pow shininess)
+                             (g/power shininess)
                              (g/* specular-level))
         light-value      (g/if (g/< lambert-term 0)
                            (g/vec3 0 0 0)
@@ -295,11 +295,11 @@
          :precision       {:float :mediump}}))))
 
 (defn draw-specular-with-shadow-map [driver draw program p mv normal-matrix vertices normals
-                                     spot-location spot-direction 
+                                     spot-location spot-direction
                                      spot-inner-angle spot-outer-angle
                                      spot-radius spot-color
                                      texture-coords
-                                     color-texture shadow-map 
+                                     color-texture shadow-map
                                      indices draw-mode fst draw-count]
   (let [angle                   (* 2 spot-outer-angle (/ 180 js/Math.PI))
         light-projection-matrix (mat/perspective angle 1 1 256)

--- a/src/cljs/gampg/utils.cljs
+++ b/src/cljs/gampg/utils.cljs
@@ -411,7 +411,7 @@
     (.viewport gl 0 0 width height)))
 
 (defn get-perspective-matrix
-  "Be sure to 
+  "Be sure to
    1. pass the WIDTH and HEIGHT of the canvas *node*, not
       the GL context
    2. (set! (.-width/height canvas-node)
@@ -445,7 +445,7 @@
     :mapping-fn     (fn [x] (or (:id x) (:element x) x))
     :input-state    (atom {})
     :input-fn       custom-input-fn
-    :produce-fn     driver/default-produce-fn}))
+    :produce-fn     driver/produce}))
 
 (defn make-frame-buffer [driver width height]
   (let [color {:width      width
@@ -518,31 +518,31 @@
                                    [   x  (- y)  z]
                                    [   x     y   z]
                                    [(- x)    y   z]
-                                   
+
                                    ;; Back face
                                    [(- x) (- y) (- z)]
                                    [(- x)    y  (- z)]
                                    [   x     y  (- z)]
                                    [   x  (- y) (- z)]
-                                   
+
                                    ;; Top face
                                    [(- x) y (- z)]
                                    [(- x) y    z]
                                    [   x  y    z]
                                    [   x  y (- z)]
-                                   
+
                                    ;; Bottom face
                                    [(- x) (- y) (- z)]
                                    [   x  (- y) (- z)]
                                    [   x  (- y)    z]
                                    [(- x) (- y)    z]
-                                   
+
                                    ;; Right face
                                    [x (- y) (- z)]
                                    [x    y  (- z)]
                                    [x    y     z]
                                    [x (- y)    z]
-                                   
+
                                    ;; Left face
                                    [(- x) (- y) (- z)]
                                    [(- x) (- y)    z]
@@ -593,31 +593,31 @@
                                    [0.0,  0.0,  1.0,]
                                    [0.0,  0.0,  1.0,]
                                    [0.0,  0.0,  1.0,]
-                                   
+
                                    ;; Back face
                                    [0.0,  0.0, -1.0,]
                                    [0.0,  0.0, -1.0,]
                                    [0.0,  0.0, -1.0,]
                                    [0.0,  0.0, -1.0,]
-                                   
+
                                    ;; Top face
                                    [0.0,  1.0,  0.0,]
                                    [0.0,  1.0,  0.0,]
                                    [0.0,  1.0,  0.0,]
                                    [0.0,  1.0,  0.0,]
-                                   
+
                                    ;; Bottom face
                                    [0.0, -1.0,  0.0,]
                                    [0.0, -1.0,  0.0,]
                                    [0.0, -1.0,  0.0,]
                                    [0.0, -1.0,  0.0,]
-                                   
+
                                    ;; Right face
                                    [1.0,  0.0,  0.0,]
                                    [1.0,  0.0,  0.0,]
                                    [1.0,  0.0,  0.0,]
                                    [1.0,  0.0,  0.0,]
-                                   
+
                                    ;; Left face
                                    [-1.0,  0.0,  0.0,]
                                    [-1.0,  0.0,  0.0,]


### PR DESCRIPTION
To use the gamma and gamma-driver jars, I've guessed a few gamma api changes:
- `gamma.api/pow` is now `gamma.api/power`
- more speculative, `gamma-driver.drivers.basic/default-produce-fn` is now `gamma-driver.drivers.basic/produce`

Everything compiles, and the examples seem to run in Safari and Chrome Canary
