### PR TITLE
compile without needing checkouts for gamma and gamma-driver

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,6 +13,7 @@
                  [fipp "0.6.2"]
                  [instaparse "1.4.0"]
                  [kovasb/gamma-driver "0.0-49"]
+                 [kovasb/gamma "0.0-135"]
                  [markdown-clj "0.9.66"]
                  [org.omcljs/om "0.8.8"]
                  [org.clojure/clojure "1.7.0-beta3"]

--- a/src/cljs/gampg/learn_gamma/apartment.cljs
+++ b/src/cljs/gampg/learn_gamma/apartment.cljs
@@ -462,7 +462,7 @@
                            reflection-direction      (g/reflect (g/* -1 light-direction) normal)
                            specular-light-weighting  (-> (g/dot reflection-direction eye-direction)
                                                          (g/max 0)
-                                                         (g/pow u-material-shininess))
+                                                         (g/power u-material-shininess))
                            diffuse-light-weighting (-> (g/dot normal light-direction)
                                                        (g/max 0))
                            light-weighting           (-> (g/+ u-ambient-color u-point-lighting-specular-color)
@@ -619,7 +619,7 @@
     :mapping-fn     (fn [x] (or (:id x) (:element x) x))
     :input-state    (atom {})
     :input-fn       my-input-fn
-    :produce-fn     driver/default-produce-fn}))
+    :produce-fn     driver/produce}))
 
 (defn reset-gl-canvas! [canvas-node]
   (let [gl     (.getContext canvas-node "webgl")

--- a/src/cljs/gampg/learn_gamma/lesson_14.cljs
+++ b/src/cljs/gampg/learn_gamma/lesson_14.cljs
@@ -90,7 +90,7 @@
                            reflection-direction      (g/reflect (g/* -1 light-direction) normal)
                            specular-light-weighting  (-> (g/dot reflection-direction eye-direction)
                                                          (g/max 0)
-                                                         (g/pow u-material-shininess))
+                                                         (g/power u-material-shininess))
                            diffuse-light-weighting (-> (g/dot normal light-direction)
                                                        (g/max 0))
                            light-weighting           (-> (g/+ u-ambient-color u-point-lighting-specular-color)

--- a/src/cljs/gampg/learn_gamma/lesson_15.cljs
+++ b/src/cljs/gampg/learn_gamma/lesson_15.cljs
@@ -107,7 +107,7 @@
                                                          (g/* 255))
                            specular-light-weighting  (-> (g/dot reflection-direction eye-direction)
                                                          (g/max 0)
-                                                         (g/pow shininess))
+                                                         (g/power shininess))
                            diffuse-light-weighting   (-> (g/dot normal light-direction)
                                                          (g/max 0))
                            light-weighting           (g/+ u-ambient-color

--- a/src/cljs/gampg/learn_gamma/programs.cljs
+++ b/src/cljs/gampg/learn_gamma/programs.cljs
@@ -146,7 +146,7 @@
                                                          (g/reflect normal))
                            specular-light-brightness (-> (g/dot reflection-direction eye-direction)
                                                          (g/max 0)
-                                                         (g/pow u-material-shininess))
+                                                         (g/power u-material-shininess))
                            specular-light-weighting  (g/* u-point-lighting-diffuse-color specular-light-brightness)
                            diffuse-light-brightness  (-> (g/dot normal light-direction)
                                                          (g/max 0))
@@ -235,7 +235,7 @@
         shininess        8 ;; Why 8?
         specular-factor  (-> (g/dot r e)
                              (g/clamp 0 1)
-                             (g/pow shininess)
+                             (g/power shininess)
                              (g/* specular-level))
         light-value      (g/if (g/< lambert-term 0)
                            (g/vec3 0 0 0)

--- a/src/cljs/gampg/utils.cljs
+++ b/src/cljs/gampg/utils.cljs
@@ -445,7 +445,7 @@
     :mapping-fn     (fn [x] (or (:id x) (:element x) x))
     :input-state    (atom {})
     :input-fn       custom-input-fn
-    :produce-fn     driver/default-produce-fn}))
+    :produce-fn     driver/produce}))
 
 (defn make-frame-buffer [driver width height]
   (let [color {:width      width


### PR DESCRIPTION
To use the gamma and gamma-driver jars, I've guessed a few gamma api changes:
- `gamma.api/pow` is now `gamma.api/power`
- more speculative, `gamma-driver.drivers.basic/default-produce-fn` is now `gamma-driver.drivers.basic/produce`

Everything compiles, and the examples seem to run in Safari and Chrome Canary
